### PR TITLE
Fixed read message of subscriber

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -212,7 +212,7 @@ func startRemotePublisherConn(logger Logger,
 	go func() {
 		<-quitChan
 		// set idle timeout
-		conn.SetDeadline(time.Now().Add(1000 * time.Millisecond))
+		conn.SetDeadline(time.Now().Add(time.Second))
 		quit = true
 	}()
 

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -235,7 +235,7 @@ func startRemotePublisherConn(logger Logger,
 			disconnectedChan <- pubUri
 			return
 		}
-		logger.Debugf("  %d", msgSize)
+		logger.Debugf("msgSize=%d", msgSize)
 		buffer = make([]byte, int(msgSize))
 		//logger.Debug("Reading message body...")
 		_, err := io.ReadFull(conn, buffer)


### PR DESCRIPTION
- Fixed timeout setting for reading messages
  - Set timeout only when shutdown subscriber and publisher is shutdown (for idle timed out)
- Fixed to close tcp conn when exiting `startRemotePublisherConn`