### PR TITLE
Add go v1.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
     - "1.9"
     - "1.10"
     - "1.11"
+    - "1.12"
+    - "1.13"
 
 env:
     - ROS_DOCKER=ros:kinetic-ros-base
@@ -23,4 +25,3 @@ install:
 
 script:
     - docker run -v $GOROOT:/usr/local/go akio/rosgo
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seqsense/rosgo
 
-go 1.12
+go 1.13
 
 require github.com/akio/rosgo v0.0.0-20181001005218-9bef6ddefa32
 


### PR DESCRIPTION
- Add golang version `"1.12"` and `"1.13"` support to `.travis.yaml`
- Update `go.mod` golang version to `1.13`